### PR TITLE
Fix error when submitting form

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -52,7 +52,7 @@ class Service extends Component
 					$purchasable->id,
 					$item->options,
 					$qty,
-					$item->note
+					$item->note ?? ''
 				);
 
 				// If the item had insufficient stock but was already in the cart, its quantity will now exceed the
@@ -139,7 +139,7 @@ class Service extends Component
 					$purchasable->id,
 					$lineItem->options,
 					$qty,
-					$lineItem->note
+					$lineItem->note ?? ''
 				);
 
 				// Only count the cart item quantity if the item has an ID (and is therefore actually in the cart).


### PR DESCRIPTION
I'm getting an error: `Argument 5 passed to craft\commerce\services\LineItems::resolveLineItem() must be of the type string, null given`

I'm not sure if this is Commerce's issue, my previous line items, or the plugin, but this is a very easy fix to just take into account it for whatever reason the line item note is null, instead of an empty string.

![screen shot 2018-10-15 at 2 46 11 pm](https://user-images.githubusercontent.com/1221575/46929032-4914d880-d089-11e8-840b-f904a83602b5.png)

Using 2.0.0-beta.11
