### PR TITLE
Ensure lineItemStatus takes into account Live status

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -122,7 +122,7 @@ class Service extends Component
 			return LineItemStatus::Deleted;
 		}
 
-		if ($purchasable instanceof Element && $purchasable->getStatus() !== Element::STATUS_ENABLED)
+		if ($purchasable instanceof Element && ($purchasable->getStatus() !== Element::STATUS_ENABLED && $purchasable->getStatus() !== Element::SCENARIO_LIVE))
 		{
 			return LineItemStatus::Disabled;
 		}


### PR DESCRIPTION
For Products (or custom Purchasable in our case), this fails to add the line item because the element's status is returned as 'live'. 