### PR TITLE
Fix error thrown when trying to reorder, but no cart exists

### DIFF
--- a/src/controllers/ReorderController.php
+++ b/src/controllers/ReorderController.php
@@ -47,6 +47,11 @@ class ReorderController extends Controller
 			{
 				$cart = $commerce->getCarts()->getCart();
 
+                		// If there's no cart yet, force a new one to be generated
+                		if (!$cart->id && !$retainCart) {
+                    			$cart = $commerce->getCarts()->getCart(true);
+                		}
+
 				// The cart ID is used in the unavailable line items check to account for cart items' quantities when
 				// determining quantity-based availability.  If we don't want to retain the current cart, then we don't
 				// need to account for the cart and therefore don't need to pass the cart ID.


### PR DESCRIPTION
When no cart exists yet for a user and they try and reorder their cart, an error is thrown.

```
Argument 1 passed to craft\commerce\services\LineItems::deleteAllLineItemsByOrderId() must be of the type integer, null given, called in /Users/joshcrawford/public_html/craft/vendor/spicyweb/craft-reorder/src/controllers/ReorderController.php on line 65
```

This fix forces the cart to be created if it doesn't already. But only if you've decided not to retain it.

To test this, just make sure to remove all Active Carts, and try and click re-order. It also happens every time a customer logs back into the site, or hits this from an external link.