### PR TITLE
FR: Add unavailable line items to session

### DIFF
--- a/src/controllers/ReorderController.php
+++ b/src/controllers/ReorderController.php
@@ -126,6 +126,8 @@ class ReorderController extends Controller
 			]);
 		}
 		
+		Craft::$app->getSession()->set('reorder.unavailable', $unavailableLineItems);
+		
 		return $this->redirectToPostedUrl();
 	}
 }


### PR DESCRIPTION
In our use-case, we're redirecting customers straight to the first step in checkout so super-easy re-ordering. However, customers are getting confused when items are missing from their orders, and we'd like to show what's missing.

There might be other ways to achieve this, and I can see you return `$unavailableLineItems` for an Ajax request or when an error occurs, but its a little tricker when redirecting (we can't make use of `setRouteParams()` either.

In this instance, we're setting a session variable, which we can then access in Twig via `{% set unavailable = craft.app.session.get('reorder.unavailable') %}` and then remove it once the order is completed.