### PR TITLE
Add ability to only reorder certain items

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ ReOrder can be configured to either keep or discard the existing cart items when
 
 These options can be configured globally in the Craft control panel and can be overridden on a case-by-case basis in your template files.
 
+ReOrder also makes it easy to allow a customer to select the items they want to reorder, if they don't want to reorder an entire order.
+
 #### Example: retain cart but disallow partial reorders
 
 ```twig
@@ -37,6 +39,23 @@ These options can be configured globally in the Craft control panel and can be o
 	<input type="hidden" name="order" value="{{ order.number }}">
 	<input type="hidden" name="retainCart" value="1">
 	<input type="hidden" name="allowPartial" value="0">
+	<button type="submit">ReOrder!</button>
+</form>
+```
+
+#### Example: allow customer to select which items to reorder
+```twig
+<form method="POST">
+	<input type="hidden" name="action" value="reorder/reorder">
+	{{ csrfInput() }}
+	{{ redirectInput('shop/checkout') }}
+	<input type="hidden" name="order" value="{{ order.number }}">
+
+	{% for item in order.lineItems %}
+		<input type="checkbox" name="reOrderItems[]" value="{{ item.id }}">
+		{# other item info #}
+	{% endfor %}
+
 	<button type="submit">ReOrder!</button>
 </form>
 ```

--- a/src/Service.php
+++ b/src/Service.php
@@ -26,9 +26,10 @@ class Service extends Component
 	 *
 	 * @param Order $order The order from which the line items will be copied.
 	 * @param bool $allowPartial Whether to allow partially available items, e.g. if there's insufficient stock.
+	 * @param array|null $itemIds The IDs of the items to copy, or `null` if copying all items.
 	 * @return bool Whether the line items were successfully copied.
 	 */
-	public function copyLineItems(Order $order, bool $allowPartial = false): bool
+	public function copyLineItems(Order $order, bool $allowPartial = false, array $itemIds = null): bool
 	{
 		$commerce = Commerce::getInstance();
 
@@ -40,6 +41,12 @@ class Service extends Component
 
 		foreach ($order->lineItems as $item)
 		{
+			// If only copying certain items, make sure this is one of them.
+			if ($itemIds !== null && !in_array($item->id, $itemIds))
+			{
+				continue;
+			}
+
 			$itemStatus = $this->_getLineItemStatus($item, $cart->id);
 			$itemAvailable = $itemStatus === LineItemStatus::Available;
 			$itemInsufficientStock = $itemStatus === LineItemStatus::InsufficientStock;
@@ -104,14 +111,21 @@ class Service extends Component
 	 *
 	 * @param Order $order The order to check.
 	 * @param int $cartId A cart ID, to check for the quantity of items already in the user's cart.
-	 * return array The line items that are unavailable and why.
+	 * @param array|null $itemIds The IDs of the items to check, or `null` if checking all items.
+	 * @return array The line items that are unavailable and why.
 	 */
-	public function getUnavailableLineItems(Order $order, int $cartId = null): array
+	public function getUnavailableLineItems(Order $order, int $cartId = null, array $itemIds = null): array
 	{
 		$unavailableLineItems = [];
 
 		foreach ($order->lineItems as $item)
 		{
+			// If only checking certain items, make sure this is one of them.
+			if ($itemIds !== null && !in_array($item->id, $itemIds))
+			{
+				continue;
+			}
+
 			$itemStatus = $this->_getLineItemStatus($item, $cartId);
 
 			if ($itemStatus !== LineItemStatus::Available)
@@ -133,15 +147,22 @@ class Service extends Component
 	 *
 	 * @param Order $order The order to check.
 	 * @param int $cartId A cart ID, to check for the quantity of items already in the user's cart.
+	 * @param array|null $itemIds The IDs of the items to check, or `null` if checking all items.
 	 * @return bool Whether the order has any available line items.
 	 * @since 1.1.0
 	 */
-	public function hasAvailableLineItems(Order $order, int $cartId = null): bool
+	public function hasAvailableLineItems(Order $order, int $cartId = null, array $itemIds = null): bool
 	{
 		$available = false;
 
 		foreach ($order->lineItems as $item)
 		{
+			// If only checking certain items, make sure this is one of them.
+			if ($itemIds !== null && !in_array($item->id, $itemIds))
+			{
+				continue;
+			}
+
 			if ($this->_getLineItemStatus($item, $cartId) === LineItemStatus::Available)
 			{
 				$available = true;

--- a/src/controllers/ReorderController.php
+++ b/src/controllers/ReorderController.php
@@ -29,6 +29,7 @@ class ReorderController extends Controller
 		$orderNumber = $request->getRequiredBodyParam('order');
 		$retainCart = $request->getBodyParam('retainCart', $defaultSettings->retainCart);
 		$allowPartial = $request->getBodyParam('allowPartial', $defaultSettings->allowPartial);
+		$copyItems = $request->getBodyParam('reOrderItems');
 
 		$isAjaxRequest = $request->getIsAjax();
 		$commerce = Commerce::getInstance();
@@ -51,12 +52,12 @@ class ReorderController extends Controller
 				// determining quantity-based availability.  If we don't want to retain the current cart, then we don't
 				// need to account for the cart and therefore don't need to pass the cart ID.
 				$cartId = $retainCart ? $cart->id : null;
-				$unavailableLineItems = ReOrder::$plugin->methods->getUnavailableLineItems($order, $cartId);
+				$unavailableLineItems = ReOrder::$plugin->methods->getUnavailableLineItems($order, $cartId, $copyItems);
 
 				// Don't account for a cart ID when checking for any available items, as the `copyLineItems()` service
 				// method will adjust items' quantities in the case of quantity-based unavailability when allowing
 				// partial reorders.
-				$hasAvailableLineItems = ReOrder::$plugin->methods->hasAvailableLineItems($order);
+				$hasAvailableLineItems = ReOrder::$plugin->methods->hasAvailableLineItems($order, null, $copyItems);
 
 				if ($hasAvailableLineItems)
 				{
@@ -68,7 +69,7 @@ class ReorderController extends Controller
 							$commerce->getLineItems()->deleteAllLineItemsByOrderId($cart->id);
 						}
 
-						$success = ReOrder::$plugin->methods->copyLineItems($order, $allowPartial);
+						$success = ReOrder::$plugin->methods->copyLineItems($order, $allowPartial, $copyItems);
 					}
 					else
 					{


### PR DESCRIPTION
With this feature, an order details page could be set up to let a customer select which items they want to reorder.  This could be useful in cases where a customer doesn't need to reorder all items; this would be more convenient than the current case, where they'd have to add all order items to their cart and then remove the items they don't need.

A basic template example of how this would work:
```twig
<form method="POST">
    <input type="hidden" name="action" value="reorder/reorder">
    {{ csrfInput() }}
    {{ redirectInput('shop/checkout') }}
    <input type="hidden" name="order" value="{{ order.number }}">

    {% for item in order.lineItems %}
        <input type="checkbox" name="reOrderItems[]" value="{{ item.id }}">
        {# other item info #}
    {% endfor %}

    <button type="submit">ReOrder!</button>
</form>
```